### PR TITLE
Adding support for Go controls, so the VR mode works in Oculus Browser on Go

### DIFF
--- a/button.js
+++ b/button.js
@@ -18,6 +18,7 @@ AFRAME.registerComponent("button", {
     let right = document.createElement("a-entity");
     right.setAttribute("vive-controls", "hand:right; model:false;");
     right.setAttribute("oculus-touch-controls", "hand:right; model:false;");
+    right.setAttribute("oculus-go-controls", "hand:right; model:false;");
     right.setAttribute("gearvr-controls", "hand:right; model:false;");
     right.setAttribute("windows-motion-controls", "hand:right; model:false;");
     right.addEventListener("triggerdown", function (evt) {
@@ -32,6 +33,7 @@ AFRAME.registerComponent("button", {
     let left = document.createElement("a-entity");
     left.setAttribute("vive-controls", "hand:left; model:false;");
     left.setAttribute("oculus-touch-controls", "hand:left; model:false;");
+    left.setAttribute("oculus-go-controls", "hand:left; model:false;");
     left.setAttribute("gearvr-controls", "hand:left; model:false;");
     left.setAttribute("windows-motion-controls", "hand:left; model:false;");
     left.addEventListener("triggerdown", function (evt) {


### PR DESCRIPTION
Fix for #8 
Tested on localhost + reverse tcp + Oculus browser v8.2 on Go. VR mode now properly process clicks. 